### PR TITLE
Fix comment typo in AuthService

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -15,7 +15,7 @@ export class AuthService {
   ) {}
 
   async signup(dto: AuthDto) {
-    // gernerate the password hash
+    // generate the password hash
     const hash = await argon.hash(dto.password);
 
     try {


### PR DESCRIPTION
## Summary
- fix a small typo in auth service comment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3e1f198832fb50ce267dffb7942