### PR TITLE
Handle missing user in JWT strategy

### DIFF
--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
@@ -19,6 +19,10 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
         id: payload.sub,
       },
     });
+
+    if (!user) {
+      throw new ForbiddenException('Access denied');
+    }
 
     delete user.hash;
 


### PR DESCRIPTION
## Summary
- throw `ForbiddenException` in JWT strategy when user not found

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3ef82d0832f8b513143ce56a240