### PR TITLE
Fix comment placement in signup service

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -28,6 +28,7 @@ export class AuthService {
       });
       delete user.hash;
 
+      // return the saved user
       return user;
     } catch (err) {
       if (err instanceof PrismaClientKnownRequestError) {
@@ -38,7 +39,6 @@ export class AuthService {
       throw err;
     }
 
-    // return the saved user
   }
 
   async signin(dto: AuthDto) {


### PR DESCRIPTION
## Summary
- move return comment inside the try block in `AuthService.signup`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3f6e1b8832fa16d1c9bf72aca60